### PR TITLE
Add PHP compile option for Opcache shared ext

### DIFF
--- a/phpfarm/custom-options.sh
+++ b/phpfarm/custom-options.sh
@@ -13,6 +13,7 @@ configoptions="$configoptions \
     --enable-fastcgi \
     --enable-gd-native-ttf \
     --enable-intl \
+    --enable-opcache \
     --with-ldap \
     --with-ldap-sasl \
     --with-bz2 \


### PR DESCRIPTION
Hi Splitbrain,

Thanks for creating this repo. I've been using it for Drupal development for legacy client sites using PHP 5.2, and it's been awesome!

Anyway I was unable to use Opcache unless I compiled it as a shared extension for PHP > 5.5. See http://php.net/manual/en/opcache.installation.php

This pull request fixes that.

Thanks,
Eugene